### PR TITLE
include the word "illumination" and more options in brightness intent

### DIFF
--- a/vocab/en-us/brightness.intent
+++ b/vocab/en-us/brightness.intent
@@ -1,13 +1,12 @@
 dim (the|your) eyes to {brightness} (percent|)
 dim down to {brightness} (percent|)
-lower the brightness of your eyes to {brightness} (percent|)
-turn (the|) brightness (down|up) to {brightness} (percent|)
-turn (down|up) (the|) brightness to {brightness} (percent|)
+lower the (brightness|illumination) of your eyes to {brightness} (percent|)
+turn (the|) (brightness|illumination) (down|up) to {brightness} (percent|)
+turn (down|up) (the|) (brightness|illumination) to {brightness} (percent|)
 brighten it up (a bit|) to {brightness} (percent|)
-(change|set|switch) to {brightness} (percent|) (eye|) brightness
-(change|set|switch) (eye|) brightness to {brightness} (percent|)
-(change|set|switch) the brightness level
-(change|set|switch) the eye brightness
+(change|set|switch) to {brightness} (percent|) (eye|) (brightness|illumination)
+(change|set|switch) (the|your) (eye|) (brightness|illumination) (level|) to {brightness} (percent|)
+(change|set|switch) (the|your) (eye|) (brightness|illumination) (level|)
 you're (too|) (bright|dim)
 you are (too|) (bright|dim)
 brighten it up


### PR DESCRIPTION
Due to the menu item for the eye brightness being marked as "ILLUM" I found myself trying to set the eye brightness by saysing "set eye illumination to 100 percent". Found it was not understood by mycroft mark 1, so have added as an option.

(note, untested as not sure how to get this onto my mycroft yet)