### PR TITLE
Become visually different when 'idle'

### DIFF
--- a/dialog/en-us/error.format.dialog
+++ b/dialog/en-us/error.format.dialog
@@ -1,2 +1,0 @@
-I couldn't understand the eye color that was entered in the web settings.  Please check what you entered.
-I wasn't able to understand the format of the web setting for eye color.

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -4,18 +4,35 @@
     "skillMetadata": {
         "sections": [
             {
-                "name": "R G B",
+                "name": "Eyes",
                 "fields": [
                     {
                         "type": "label",
-                        "label": "Eye color can be a <a href='https://github.com/MycroftAI/mycroft-mark-1/blob/master/dialog/en-us/colors.value'>color name</a>, RGB triple, or hex color code.  <P>Examples:<ul><li>Green</li><li>(34, 167, 240)</li><li>#019FDE</li></ul>"
+                        "label": "Eye color can be a <a href='https://github.com/MycroftAI/mycroft-mark-1/blob/master/dialog/en-us/colors.value'>color name</a>, such as 'default' or 'deep pink'; an RGB triple like '(34, 167, 240)'; or a hex color code like '#22A7F0'"
                     },
                     {
                         "name": "eye color",
                         "type": "text",
                         "label": "Eye Color",
-                        "placeholder": "e.g. (34, 167, 240)",
-                        "value": ""
+                        "placeholder": "default",
+                        "value": "default"
+                    },
+                    {
+                        "type": "checkbox",
+                        "name": "auto_dim_eyes",
+                        "label": "Dim when not active",
+                        "value": "false"
+                    }
+                ]
+            },
+            {
+                "name": "Behavior",
+                "fields": [
+                    {
+                        "type": "checkbox",
+                        "name": "use_listening_beep",
+                        "label": "Play beep when listening",
+                        "value": "true"
                     }
                 ]
             }

--- a/vocab/en-us/eye.color.intent
+++ b/vocab/en-us/eye.color.intent
@@ -1,4 +1,4 @@
-(change|set) (the|your) (eye|eyes) (color|colors|) to {color}
+(change|set) (the|your|) (eye|eyes) (color|colors|) to {color}
 (change|set) eye (color|colors) to something {color}
 (change|set) (your|) eyes to (a|an|) {color} (color|)
 (change|set) eyes to some {color} color

--- a/vocab/en-us/get.color.web.intent
+++ b/vocab/en-us/get.color.web.intent
@@ -1,9 +1,0 @@
-get the eye color from web settings
-get the eye color from web
-get the eye color from settings 
-retrieve eye color from web settings
-retrieve eye color from web
-eye color from web
-eye color web settings
-update eye color from web
-update eye color from settings


### PR DESCRIPTION
Prototype the Mark 1 face change to a dimmer eye state when the system
has been idle for some time, then brightens back up after being
invoked again.

Details:
* Made auto-dim a configuration
* Added 12/18 second checks for idle
* Also allow control of wake-up beep

Also enhanced interaction between webUI and voice with regards to color:
* Made webUI color changes take effect immediately and colors synchronize
* Simplified color parsing/validation