### PR TITLE
Update for 18.08

### DIFF
--- a/dialog/en-us/color.not.found.dialog
+++ b/dialog/en-us/color.not.found.dialog
@@ -1,3 +1,3 @@
-sorry, that color is not an option. Try asking me to set a custom eye color.
+Sorry, that color is not an option. Try asking me to set a custom eye color.
 I do not have that color available, but I can set custom eye colors.
 My eyes cannot turn into that color. Perhaps you should ask me to set a custom eye color.

--- a/dialog/en-us/error.set.color.dialog
+++ b/dialog/en-us/error.set.color.dialog
@@ -1,2 +1,2 @@
-Sorry, There was an error setting the color.
+Sorry, there was an error setting the color.
 Looks like I had an error trying to set the color.

--- a/dialog/en-us/set.color.success.dialog
+++ b/dialog/en-us/set.color.success.dialog
@@ -1,3 +1,3 @@
-Cool. check out my eyes.
-Okay. Do i look better now?
+Cool. Check out my eyes.
+Okay. Do I look better now?
 That's a good color. Look at me now.


### PR DESCRIPTION
Several minor changes and a bugfix:
* Removed the support for old versions (pre enclosure.eyes_setpixel())
* Switched to new settings initialization technique (default in the constructor)
* BUGFIX:  The web setting was comming down incorrectly all the time, which made
  it override any locally set color.  Revamped the scheme to behave properly,
  only overriding if the websetting changes.
* Added handler for new "mycroft.eyes.default" message.  This changes the eyes
  back to the user-selected color.

*